### PR TITLE
Fix Xlib screen mode being dotclock instead of the true hz.

### DIFF
--- a/pyglet/display/xlib.py
+++ b/pyglet/display/xlib.py
@@ -276,7 +276,7 @@ class XlibScreenMode(ScreenMode):
         self.info = info
         self.width = info.hdisplay
         self.height = info.vdisplay
-        self.rate = info.dotclock
+        self.rate = (info.dotclock * 1000) / (info.htotal * info.vtotal)
         self.depth = None
 
 


### PR DESCRIPTION
Fix Xlib screen mode being dotclock instead of the true hz.  In Windows, the .rate returns the hz of the display, but on Linux, it returns dotclock, which is not the same. This fixes that issue.